### PR TITLE
bugfix: login page not accepting credential inputs

### DIFF
--- a/src/components/authorization/QAuthorization.vue
+++ b/src/components/authorization/QAuthorization.vue
@@ -33,18 +33,16 @@
                 :register-page-description="registerPageDescription"
                 :privacy-text="privacyText"
                 @onSubmitRegister="onSubmitRegister"
-                :register-form-first-name="registerFormFirstName"
-                :register-form-last-name="registerFormLastName"
-                :register-form-email="registerFormEmail"
-                :register-form-password="registerFormPassword"
+                v-on="$_registrationEvents"
+                v-bind="$_registrationProps"
               />
             </div>
 
             <!-- Login Page -->
             <div v-else>
               <QAuthorizationLoginForm
-                :email-login="emailLogin"
-                :password-login="passwordLogin"
+                v-on="$_loginEvents"
+                v-bind="$_loginProps"
                 @handleLogin="handleLogin"
               />
             </div>
@@ -85,23 +83,23 @@ import QAuthorizationSwitchButton from './QAuthorizationSwitchButton'
 import QAuthorizationRegisterPage from './registration/QAuthorizationRegisterPage'
 import QAuthorizationLoginForm from './login/QAuthorizationLoginForm'
 import QAuthorizationSlider from './QAuthorizationSlider'
+import RegistrationMixin from './mixins/registration'
+import LoginMixin from './mixins/login'
+import props from './mixins/props'
 export default {
   name: 'QAuthorization',
+  mixins: [RegistrationMixin, LoginMixin],
   props: {
     companyInfo: Object,
     tagLine: Object,
-    emailLogin: String,
-    passwordLogin: String,
     registerPageDescription: Object,
     slide: Number,
     reviewsSlide: Array,
     showRightSide: Boolean,
     privacyText: String,
     switchButtonText: Object,
-    registerFormFirstName: String,
-    registerFormLastName: String,
-    registerFormEmail: String,
-    registerFormPassword: String
+    ...props.login,
+    ...props.registration
   },
   components: { QAuthorizationSwitchButton, QAuthorizationRegisterPage, QAuthorizationLoginForm, QAuthorizationSlider },
   data () {

--- a/src/components/authorization/login/QAuthorizationLoginForm.vue
+++ b/src/components/authorization/login/QAuthorizationLoginForm.vue
@@ -6,8 +6,8 @@
     <q-input
       filled
       type="email"
-      v-model="mutableEmailLogin"
-      @input="$emit('update:emailLogin', mutableEmailLogin)"
+      :value="emailLogin"
+      @input="$emit('update:email-login', $event)"
       label="Email"
       lazy-rules
       :rules="[
@@ -18,8 +18,8 @@
     <q-input
       filled
       type="password"
-      v-model="mutablePasswordLogin"
-      @input="$emit('update:passwordLogin', mutablePasswordLogin)"
+      :value="passwordLogin"
+      @input="$emit('update:password-login', $event)"
       label="Password"
       lazy-rules
       :rules="[
@@ -37,23 +37,18 @@
 </template>
 
 <script>
+
+import props from '../mixins/props'
 export default {
   name: 'QAuthorizationLoginForm',
   props: {
-    emailLogin: String,
-    passwordLogin: String
-  },
-  data () {
-    return {
-      mutableEmailLogin: this.emailLogin,
-      mutablePasswordLogin: this.passwordLogin
-    }
+    ...props.login
   },
   methods: {
     handleLogin () {
       this.$emit('handleLogin', {
-        emailLogin: this.mutableEmailLogin,
-        passwordLogin: this.mutablePasswordLogin
+        emailLogin: this.emailLogin,
+        passwordLogin: this.passwordLogin
       })
     }
   }

--- a/src/components/authorization/mixins/login.js
+++ b/src/components/authorization/mixins/login.js
@@ -1,0 +1,17 @@
+
+export default {
+  computed: {
+    $_loginProps () {
+      return {
+        'email-login': this.emailLogin,
+        'password-login': this.passwordLogin
+      }
+    }
+  },
+  created () {
+    this.$_loginEvents = {
+      'update:email-login': val => this.$emit('update:email-login', val),
+      'update:password-login': val => this.$emit('update:password-login', val)
+    }
+  }
+}

--- a/src/components/authorization/mixins/props.js
+++ b/src/components/authorization/mixins/props.js
@@ -1,0 +1,12 @@
+export default {
+  login: {
+    emailLogin: String,
+    passwordLogin: String
+  },
+  registration: {
+    registerFormFirstName: String,
+    registerFormLastName: String,
+    registerFormEmail: String,
+    registerFormPassword: String
+  }
+}

--- a/src/components/authorization/mixins/registration.js
+++ b/src/components/authorization/mixins/registration.js
@@ -1,0 +1,21 @@
+
+export default {
+  computed: {
+    $_registrationProps () {
+      return {
+        'register-form-first-name': this.registerFormFirstName,
+        'register-form-last-name': this.registerFormLastName,
+        'register-form-email': this.registerFormEmail,
+        'register-form-password': this.registerFormPassword
+      }
+    }
+  },
+  created () {
+    this.$_registrationEvents = {
+      'update:register-form-first-name': val => this.$emit('update:register-form-first-name', val),
+      'update:register-form-last-name': val => this.$emit('update:register-form-last-name', val),
+      'update:register-form-email': val => this.$emit('update:register-form-email', val),
+      'update:register-form-password': val => this.$emit('update:register-form-password', val)
+    }
+  }
+}

--- a/src/components/authorization/registration/QAuthorizationRegisterForm.vue
+++ b/src/components/authorization/registration/QAuthorizationRegisterForm.vue
@@ -6,8 +6,8 @@
     <div class="row no-wrap">
       <q-input
         filled
-        v-model="mutableFirstName"
-        @input="$emit('update:registerFormFirstName', mutableFirstName)"
+        :value="registerFormFirstName"
+        @input="$emit('update:register-form-first-name', $event)"
         label="First Name"
         lazy-rules
         class="col-6 q-pr-md"
@@ -16,8 +16,8 @@
 
       <q-input
         filled
-        v-model="mutableLastName"
-        @input="$emit('update:registerFormLastName', mutableLastName)"
+        :value="registerFormLastName"
+        @input="$emit('update:register-form-last-name', $event)"
         label="Last Name"
         lazy-rules
         class="col-6 q-pl-md"
@@ -30,8 +30,8 @@
     <q-input
       filled
       type="email"
-      v-model="mutableEmail"
-      @input="$emit('update:registerFormEmail', mutableEmail)"
+      :value="registerFormEmail"
+      @input="$emit('update:register-form-email', $event)"
       label="Email"
       lazy-rules
       :rules="[
@@ -42,8 +42,8 @@
     <q-input
       filled
       type="password"
-      v-model="mutablePassword"
-      @input="$emit('update:registerFormPassword', mutablePassword)"
+      :value="registerFormPassword"
+      @input="$emit('update:register-form-password', $event)"
       label="Choose a Password"
       lazy-rules
       :rules="[
@@ -61,29 +61,19 @@
 </template>
 
 <script>
+import props from '../mixins/props'
 export default {
   name: 'QAuthorizationRegisterForm',
   props: {
-    registerFormFirstName: String,
-    registerFormLastName: String,
-    registerFormEmail: String,
-    registerFormPassword: String
-  },
-  data () {
-    return {
-      mutableFirstName: this.registerFormFirstName,
-      mutableLastName: this.registerFormLastName,
-      mutableEmail: this.registerFormEmail,
-      mutablePassword: this.registerFormPassword
-    }
+    ...props.registration
   },
   methods: {
     onSubmitRegister () {
       this.$emit('onSubmitRegister', {
-        firstName: this.mutableFirstName,
-        lastName: this.mutableLastName,
-        email: this.mutableEmail,
-        password: this.mutablePassword
+        firstName: this.registerFormFirstName,
+        lastName: this.registerFormLastName,
+        email: this.registerFormEmail,
+        password: this.registerFormPassword
       })
     }
   }

--- a/src/components/authorization/registration/QAuthorizationRegisterPage.vue
+++ b/src/components/authorization/registration/QAuthorizationRegisterPage.vue
@@ -10,10 +10,8 @@
 
     <!-- Register form -->
     <QAuthorizationRegisterForm
-      :register-form-first-name="registerFormFirstName"
-      :register-form-last-name="registerFormLastName"
-      :register-form-email="registerFormEmail"
-      :register-form-password="registerFormPassword"
+      v-on="$_registrationEvents"
+      v-bind="$_registrationProps"
       @onSubmitRegister="onSubmitRegister"
     />
     <div class="text-caption text-grey-5 q-authorization__recaptcha-warning">
@@ -24,15 +22,15 @@
 
 <script>
 import QAuthorizationRegisterForm from './QAuthorizationRegisterForm'
+import RegistrationMixin from '../mixins/registration'
+import props from '../mixins/props'
 export default {
   name: 'QAuthorizationRegisterPage',
+  mixins: [RegistrationMixin],
   props: {
     registerPageDescription: Object,
     privacyText: String,
-    registerFormFirstName: String,
-    registerFormLastName: String,
-    registerFormEmail: String,
-    registerFormPassword: String
+    ...props.registration
   },
   components: { QAuthorizationRegisterForm },
   data () {

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -80,7 +80,7 @@ export default {
   },
   methods: {
     onSubmitRegister (data) {
-      console.log('Submitted Register Data', data)
+      this.debug('Submitted Register Data', data)
       this.registerFormFirstName = data.registerFormFirstName
       this.registerFormLastName = data.registerFormLastName
       this.registerFormEmail = data.registerFormEmail


### PR DESCRIPTION
Login page was not accepting different creds/registration information other than default ones. `$emit`, `sync` was not propagated/linked properly.
Also removed unnecessary local states and cleaned up by applying mixins to avoid repeated codes.